### PR TITLE
Add script for automatic papers download

### DIFF
--- a/download.py
+++ b/download.py
@@ -1,53 +1,106 @@
 import os
+import re
 import urllib2
+import shutil
+import argparse
 import mistune
 import bs4 as BeautifulSoup
 
 def download_pdf(link, location, name):
-	try:
-	    response = urllib2.urlopen(link)
-	    file = open(os.path.join(location, name), 'w')
-	    file.write(response.read())
-	    file.close()
-	except urllib2.HTTPError:
-		print('>>> Error 404: cannot be downloaded!\n')    
+    try:
+        response = urllib2.urlopen(link)
+        file = open(os.path.join(location, name), 'w')
+        file.write(response.read())
+        file.close()
+    except urllib2.HTTPError:
+        print('>>> Error 404: cannot be downloaded!\n') 
+        raise   
 
 def clean_pdf_link(link):
-	if 'arxiv' in link:
-		link = link.replace('abs', 'pdf')	
-	return link
+    if 'arxiv' in link:
+        link = link.replace('abs', 'pdf')   
+        if not(link.endswith('.pdf')):
+            link = '.'.join((link, 'pdf'))
+    if 'github' in link:
+        link = '.'.join((link, 'html'))        
+    return link
 
-def clean_header(text):
-	return text.replace(' ', '_').replace('/', '_')	   
+def clean_text(text, replacements = {' ': '_', '/': '_', '.': '', '"': ''}):
+    for key, rep in replacements.items():
+        text = text.replace(key, rep)
+    return text    
+
+def print_title(title, pattern = "-"):
+    print('\n'.join(("", title, pattern * len(title)))) 
+
+def get_extension(link):
+    extension = os.path.splitext(link)[1][1:]
+    if extension in ['pdf', 'html']:
+        return extension
+    if 'pdf' in extension:
+        return 'pdf'    
+    return 'pdf'    
+
+def shorten_title(title):
+    m1 = re.search('[[0-9]*]', title)
+    m2 = re.search('".*"', title)
+    if m1:
+        title = m1.group(0)
+    if m2:
+        title = ' '.join((title, m2.group(0)))   
+    return title[:50] + ' [...]'    
+
 
 if __name__ == '__main__':
 
-	with open('README.md') as readme:
-		readme_html = mistune.markdown(readme.read())
-		readme_soup = BeautifulSoup.BeautifulSoup(readme_html, "html.parser")
+    parser = argparse.ArgumentParser(description = 'Download all the PDF/HTML links into README.md')
+    parser.add_argument('-d', action="store", dest="directory")
+    parser.add_argument('--no-html', action="store_true", dest="nohtml", default = False)
+    parser.add_argument('--overwrite', action="store_true", default = False)    
+    results = parser.parse_args()
 
-	point = readme_soup.find_all('h1')[1]
+    output_directory = 'pdfs' if results.directory is None else results.directory
 
-	while point is not None:
-		if point.name == 'h1':
-			level1_directory = os.path.join('pdfs', clean_header(point.text))
-			os.makedirs(level1_directory)
-			print('\n'.join(("", point.text, "+" * len(point.text))))
+    forbidden_extensions = ['html', 'htm'] if results.nohtml else []
 
-		elif point.name == 'h2':
-			current_directory = os.path.join(level1_directory, clean_header(point.text))
-			os.mkdir(current_directory)
-			print('\n'.join(("", point.text, "-" * len(point.text))))
+    if results.overwrite and os.path.exists(output_directory):
+        shutil.rmtree(output_directory)
 
-		elif point.name == 'p':
-			link = clean_pdf_link(point.find('a').attrs['href'])
-			extension = os.path.splitext(link)[1][1:]
-			extension = 'pdf' if extension not in ['pdf', 'html'] else extension
-			name = point.text.split('[' + extension + ']')[0].replace('.', '').replace('/', '_')
-			if link is not None:
-				print(name + ' (' + link + ')')
-				download_pdf(link, current_directory, '.'.join((name, extension)))
-		
-		point = point.next_sibling			
+    with open('README.md') as readme:
+        readme_html = mistune.markdown(readme.read())
+        readme_soup = BeautifulSoup.BeautifulSoup(readme_html, "html.parser")
 
+    point = readme_soup.find_all('h1')[1]
 
+    failures = []
+    while point is not None:
+        if point.name:
+            if re.search('h[1-2]', point.name):
+                if point.name == 'h1':
+                    h1_directory = os.path.join(output_directory, clean_text(point.text))
+                    current_directory = h1_directory
+                elif point.name == 'h2':
+                    current_directory = os.path.join(h1_directory, clean_text(point.text))  
+                os.makedirs(current_directory)
+                print_title(point.text)
+
+            if point.name == 'p':
+                link = point.find('a')
+                if link is not None:
+                    link = clean_pdf_link(link.attrs['href'])
+                    ext = get_extension(link)
+                    if not ext in forbidden_extensions:
+                        print(shorten_title(point.text) + ' (' + link + ')')
+                        try:
+                            name = clean_text(point.text.split('[' + ext + ']')[0])
+                            download_pdf(link, current_directory, '.'.join((name, ext)))
+                        except:
+                            failures.append(point.text)
+                        
+        point = point.next_sibling          
+
+    print('Done!')
+    if failures:
+        print('Some downloads have failed:')
+        for fail in failures:
+            print('> ' + fail)

--- a/download.py
+++ b/download.py
@@ -1,0 +1,52 @@
+import os
+import urllib2
+import mistune
+import bs4 as BeautifulSoup
+
+def download_pdf(link, location, name):
+	try:
+	    response = urllib2.urlopen(link)
+	    file = open(os.path.join(location, name), 'w')
+	    file.write(response.read())
+	    file.close()
+	except urllib2.HTTPError:
+		print('>>> Error 404: cannot be downloaded!\n')    
+
+def clean_pdf_link(link):
+	if 'arxiv' in link:
+		link = link.replace('abs', 'pdf')	
+	return link
+
+def clean_header(text):
+	return text.replace(' ', '_').replace('/', '_')	   
+
+if __name__ == '__main__':
+
+	with open('README.md') as readme:
+		readme_html = mistune.markdown(readme.read())
+		readme_soup = BeautifulSoup.BeautifulSoup(readme_html, "html.parser")
+
+	point = readme_soup.find_all('h1')[1]
+
+	while point is not None:
+		if point.name == 'h1':
+			level1_directory = os.path.join('pdfs', clean_header(point.text))
+			os.makedirs(level1_directory)
+			print('\n'.join((point.text, "+" * len(point.text), "")))
+
+		elif point.name == 'h2':
+			current_directory = os.path.join(level1_directory, clean_header(point.text))
+			os.mkdir(current_directory)
+			print('\n'.join((point.text, "+" * len(point.text), "")))
+
+		elif point.name == 'p':
+			link = clean_pdf_link(point.find('a').attrs['href'])
+			extension = os.path.splitext(link)[1][1:]
+			name = point.text.split('[' + extension + ']')[0].replace('.', '').replace('/', '_')
+			if link is not None:
+				print(name + ' (' + link + ')')
+				download_pdf(link, current_directory, '.'.join((name, extension)))
+		
+		point = point.next_sibling			
+
+

--- a/download.py
+++ b/download.py
@@ -32,16 +32,17 @@ if __name__ == '__main__':
 		if point.name == 'h1':
 			level1_directory = os.path.join('pdfs', clean_header(point.text))
 			os.makedirs(level1_directory)
-			print('\n'.join((point.text, "+" * len(point.text), "")))
+			print('\n'.join(("", point.text, "+" * len(point.text))))
 
 		elif point.name == 'h2':
 			current_directory = os.path.join(level1_directory, clean_header(point.text))
 			os.mkdir(current_directory)
-			print('\n'.join((point.text, "+" * len(point.text), "")))
+			print('\n'.join(("", point.text, "-" * len(point.text))))
 
 		elif point.name == 'p':
 			link = clean_pdf_link(point.find('a').attrs['href'])
 			extension = os.path.splitext(link)[1][1:]
+			extension = 'pdf' if extension not in ['pdf', 'html'] else extension
 			name = point.text.split('[' + extension + ']')[0].replace('.', '').replace('/', '_')
 			if link is not None:
 				print(name + ' (' + link + ')')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+mistune>=0.7.2
+beautifulsoup4>=4.4.1


### PR DESCRIPTION
Hello,

I'd like to propose a Python script for automatic download of all the papers listed in the README. It works properly on the current list for HTML and PDF links. It downloads all the documents into a folder tree (located at ```pdfs/```) following the structure given by the Markdown headers of the ```README.md``` file

The only file not working is the Github link to the Deep Learning Book.

The script has been tested with Python 2.7.10 on MacOS. The script with a bit of tweaking should work with 2.7 and 3.0+.

I provide all the necessary into ```download.py```. ```requirements.txt``` is useful to setup the right environnement using the commands.
```
virtualenv --python=2.7 py
source py/bin/activate
pip install -r requirements.txt
python download.py
```

Is that something that can be useful to the project ? 
If yes, I will improve the script which remains quite basic for now.