### PR TITLE
non-ascii parentheses were breaking download.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ I would continue adding papers to this roadmap.
 
 **[3]** Hinton, Geoffrey E., and Ruslan R. Salakhutdinov. "**Reducing the dimensionality of data with neural networks**." Science 313.5786 (2006): 504-507. [[pdf]](http://www.cs.toronto.edu/~hinton/science.pdf) **(Milestone, Show the promise of deep learning)** :star::star::star:
 
-## 1.3 ImageNet Evolution（Deep Learning broke out from here）
+## 1.3 ImageNet Evolution (Deep Learning broke out from here)
 
 **[4]** Krizhevsky, Alex, Ilya Sutskever, and Geoffrey E. Hinton. "**Imagenet classification with deep convolutional neural networks**." Advances in neural information processing systems. 2012. [[pdf]](http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf) **(AlexNet, Deep Learning Breakthrough)** :star::star::star::star::star:
 
@@ -259,7 +259,7 @@ I would continue adding papers to this roadmap.
 
 ## 3.5 Machine Translation
 
-> Some milestone papers are listed in RNN / Seq-to-Seq topic. 
+> Some milestone papers are listed in RNN / Seq-to-Seq topic.
 
 **[1]** Luong, Minh-Thang, et al. "**Addressing the rare word problem in neural machine translation**." arXiv preprint arXiv:1410.8206 (2014). [[pdf]](http://arxiv.org/pdf/1410.8206) :star::star::star::star:
 
@@ -294,7 +294,7 @@ I would continue adding papers to this roadmap.
 
 ## 3.7 Art
 
-**[1]** Mordvintsev, Alexander; Olah, Christopher; Tyka, Mike (2015). "**Inceptionism: Going Deeper into Neural Networks**". Google Research. [[html]](https://research.googleblog.com/2015/06/inceptionism-going-deeper-into-neural.html) **(Deep Dream)** 
+**[1]** Mordvintsev, Alexander; Olah, Christopher; Tyka, Mike (2015). "**Inceptionism: Going Deeper into Neural Networks**". Google Research. [[html]](https://research.googleblog.com/2015/06/inceptionism-going-deeper-into-neural.html) **(Deep Dream)**
 :star::star::star::star:
 
 **[2]** Gatys, Leon A., Alexander S. Ecker, and Matthias Bethge. "**A neural algorithm of artistic style**." arXiv preprint arXiv:1508.06576 (2015). [[pdf]](http://arxiv.org/pdf/1508.06576) **(Outstanding Work, most successful method currently)** :star::star::star::star::star:
@@ -321,15 +321,3 @@ I would continue adding papers to this roadmap.
 ## 3.13 Neural Network Chip
 
 ## 3.14 Other Frontiers
-
-
-
-
-
-
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -324,17 +324,3 @@ I would continue adding papers to this roadmap.
 
 **[5]** Dai, J., He, K., Sun, J. "**Instance-sensitive Fully Convolutional Networks**." arXiv preprint arXiv:1603.08678 (2016). [[pdf]](https://arxiv.org/pdf/1603.08678v1.pdf) :star::star::star:
 
-
-## 3.9 Audio
-
-## 3.10 Game
-
-## 3.11 Knowledge Graph
-
-## 3.12 Recommender Systems
-
-## 3.13 Bioinformatics / Computational Biology
-
-## 3.14 Neural Network Chip
-
-## 3.15 Other Frontiers

--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ I would continue adding papers to this roadmap.
 
 **[2]** Mikolov, et al. "**Distributed representations of words and phrases and their compositionality**." ANIPS(2013): 3111-3119 [[pdf]](http://papers.nips.cc/paper/5021-distributed-representations-of-words-and-phrases-and-their-compositionality.pdf) **(word2vec)** :star::star::star:
 
-**[3]** Sutskever, et al. "**“Sequence to sequence learning with neural networks**." ANIPS(2014) [[pdf]](http://papers.nips.cc/paper/5346-sequence-to-sequence-learning-with-neural-networks.pdf) :star::star::star:
+**[3]** Sutskever, et al. "**Sequence to sequence learning with neural networks**." ANIPS(2014) [[pdf]](http://papers.nips.cc/paper/5346-sequence-to-sequence-learning-with-neural-networks.pdf) :star::star::star:
 
-**[4]** Ankit Kumar, et al. "**“Ask Me Anything: Dynamic Memory Networks for Natural Language Processing**." arXiv preprint arXiv:1506.07285(2015) [[pdf]](https://arxiv.org/abs/1506.07285) :star::star::star::star:
+**[4]** Ankit Kumar, et al. "**Ask Me Anything: Dynamic Memory Networks for Natural Language Processing**." arXiv preprint arXiv:1506.07285(2015) [[pdf]](https://arxiv.org/abs/1506.07285) :star::star::star::star:
 
 **[5]** Yoon Kim, et al. "**Character-Aware Neural Language Models**." NIPS(2015) arXiv preprint arXiv:1508.06615(2015) [[pdf]](https://arxiv.org/abs/1508.06615) :star::star::star::star:
 


### PR DESCRIPTION
`download.py` was failing: 

```
  File "download.py", line 34, in print_title
    print('\n'.join(('', title, pattern * len(title))))
UnicodeEncodeError: 'ascii' codec can't encode character u'\uff08' in position 23: ordinal not in range(128)
```

The reason was the non-ascii parentheses in 1.3. 

Also, atom-atically removed some whitespace. 
