### PR TITLE
download.py fix: Appending .html breaks github downloads

### DIFF
--- a/download.py
+++ b/download.py
@@ -21,8 +21,6 @@ def clean_pdf_link(link):
         link = link.replace('abs', 'pdf')   
         if not(link.endswith('.pdf')):
             link = '.'.join((link, 'pdf'))
-    if 'github' in link:
-        link = '.'.join((link, 'html'))        
     return link
 
 def clean_text(text, replacements = {' ': '_', '/': '_', '.': '', '"': ''}):


### PR DESCRIPTION
I'm not sure why this was there originally, but it breaks the downloading of the Deep Learning book. Removing .html fixes it.