### PR TITLE
Fix deep learning book download

### DIFF
--- a/download.py
+++ b/download.py
@@ -23,8 +23,6 @@ def clean_pdf_link(link):
         link = link.replace('abs', 'pdf')   
         if not(link.endswith('.pdf')):
             link = '.'.join((link, 'pdf'))
-    if 'github' in link:
-        link = '.'.join((link, 'html'))        
     return link
 
 def clean_text(text, replacements = {' ': '_', '/': '_', '.': '', '"': ''}):


### PR DESCRIPTION
There is a problem when downloading the Deep Learning book. In the method, **clean_pdf_link**, if there the link has the _github_ string, it add a _.html_ add the end of the link, making:

https://github.com/HFTrader/DeepLearningBook/raw/master/DeepLearningBook.pdf

Turn into:

https://github.com/HFTrader/DeepLearningBook/raw/master/DeepLearningBook.pdf.html

Which causes an error to download the file. I have checked the README.md file, and this is the only file that has a _github_ string on its link. Therefore, I think just removing that check solves the problem.