### PR TITLE
Specify encoding utf-8

### DIFF
--- a/download.py
+++ b/download.py
@@ -83,8 +83,9 @@ if __name__ == '__main__':
 
     if results.overwrite and os.path.exists(output_directory):
         shutil.rmtree(output_directory)
-
-    with open('README.md') as readme:
+        
+    enc='utf-8'
+    with open('README.md', 'r', encoding=enc) as readme:
         readme_html = mistune.markdown(readme.read())
         readme_soup = BeautifulSoup.BeautifulSoup(readme_html, "html.parser")
 


### PR DESCRIPTION
To fix the UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 33091: character maps to <undefined> error in Windows